### PR TITLE
Update mijnafvalwijzer to https

### DIFF
--- a/trashapis.js
+++ b/trashapis.js
@@ -72,7 +72,7 @@ function mijnAfvalWijzer(postcode, housenumber, country, callback)
 {
 	console.log("Checking Mijn Afval Wijzer");
 
-    generalMijnAfvalwijzerApiImplementation(postcode, housenumber, country, "http://www.mijnafvalwijzer.nl/nl/", callback);
+    generalMijnAfvalwijzerApiImplementation(postcode, housenumber, country, "https://www.mijnafvalwijzer.nl/nl/", callback);
 }
 
 function afvalwijzerArnhem(postcode, housenumber, country, callback)


### PR DESCRIPTION
The http link now gives a 301 permanently moved, while the https provides a 200 OK response.

Since you look for a code 200 else return invalid location, the http link is returning an invalid location. 