### PR TITLE
Adding support for Peel en Maas Afvalkalender

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lot of cities are supported with this trashcan reminder. If your city is not s
 - [Afvalkalender ACV](https://www.acv-groep.nl/)
 - [Afvalkalender Circulus-Berkel](https://mijn.circulus-berkel.nl)
 - [Afvalkalender Meerlanden](https://afvalkalender.meerlanden.nl)
+- [Afvalkalender Peel en Maas](https://afvalkalender.peelenmaas.nl)
 - [Afvalkalender Venray](https://afvalkalender.venray.nl)
 - [Avalex](https://www.avalex.nl/)
 - [Cure](https://afvalkalender.cure-afvalbeheer.nl)

--- a/app.json
+++ b/app.json
@@ -35,6 +35,10 @@
 			{
 				"name": "Jeroen Brosens",
 				"email": "j.brosens@gmail.com"
+			},
+			{
+				"name": "Maurice Wingbermuhle",
+				"email": "maurice@mwict.nl"
 			}
 		]
 	},

--- a/settings/index.html
+++ b/settings/index.html
@@ -33,6 +33,7 @@
 				<option value="afc">Afvalkalender Cyclus</option>
 				<option value="dar">Afvalkalender Dar</option>
 				<option value="akm">Afvalkalender Meerlanden</option>
+				<option value="akpm">Afvalkalender Peel en Maas</option>
 				<option value="rd4">Afvalkalender RD4</option>
 				<option value="afrm">Afvalkalender RMN</option>
 				<option value="rov">Afvalkalender ROVA</option>

--- a/trashapis.js
+++ b/trashapis.js
@@ -40,6 +40,10 @@ function afvalkalenderMeerlanden(postcode, housenumber, country, callback) {
     newGeneralAfvalkalendersNederland(postcode, housenumber, country, 'afvalkalender.meerlanden.nl', callback);
 }
 
+function afvalkalenderPeelEnMaas(postcode, housenumber, country, callback) {
+    newGeneralAfvalkalendersNederland(postcode, housenumber, country, 'afvalkalender.peelenmaas.nl', callback);
+}
+
 function afvalkalenderVenray(postcode, housenumber, country, callback) {
     newGeneralAfvalkalendersNederland(postcode, housenumber, country, 'afvalkalender.venray.nl', callback);
 }
@@ -760,6 +764,7 @@ apiList.push({ name: "Twente Milieu", id: "twm", execute: twenteMilieu });
 apiList.push({ name: "Gemeente Hellendoorn", id: "geh", execute: gemeenteHellendoorn });
 apiList.push({ name: "Recyclemanager", id: "remg", execute: recycleManager });
 apiList.push({ name: "Afvalkalender Meerlanden", id: "akm", execute: afvalkalenderMeerlanden });
+apiList.push({ name: "Afvalkalender Peel en Maas", id: "akm", execute: afvalkalenderPeelEnMaas });
 apiList.push({ name: "Afvalkalender Venray", id: "akvr", execute: afvalkalenderVenray });
 apiList.push({ name: "Inzamelkalender HVC", id: "hvc", execute: inzamelkalenderHVC });
 apiList.push({ name: "Dar Afvalkalender", id: "dar", execute: darAfvalkalender });

--- a/trashapis.js
+++ b/trashapis.js
@@ -764,7 +764,7 @@ apiList.push({ name: "Twente Milieu", id: "twm", execute: twenteMilieu });
 apiList.push({ name: "Gemeente Hellendoorn", id: "geh", execute: gemeenteHellendoorn });
 apiList.push({ name: "Recyclemanager", id: "remg", execute: recycleManager });
 apiList.push({ name: "Afvalkalender Meerlanden", id: "akm", execute: afvalkalenderMeerlanden });
-apiList.push({ name: "Afvalkalender Peel en Maas", id: "akm", execute: afvalkalenderPeelEnMaas });
+apiList.push({ name: "Afvalkalender Peel en Maas", id: "akpm", execute: afvalkalenderPeelEnMaas });
 apiList.push({ name: "Afvalkalender Venray", id: "akvr", execute: afvalkalenderVenray });
 apiList.push({ name: "Inzamelkalender HVC", id: "hvc", execute: inzamelkalenderHVC });
 apiList.push({ name: "Dar Afvalkalender", id: "dar", execute: darAfvalkalender });


### PR DESCRIPTION
Adding support for the Peel en Maas Afvalkalender, to support the Peel en Maas region:
 - Baarlo
 - Beringe
 - Egchel
 - Grashoek
 - Helden
 - Kessel
 - Kessel-Eik
 - Koningslust
 - Maasbree
 - Meijel
 - Panningen