### PR TITLE
validateStreetRequest needs to be a POST request

### DIFF
--- a/trashapis.js
+++ b/trashapis.js
@@ -633,6 +633,7 @@ function generalImplementationRecycleApp(postcode, housenumber, street, country)
                 var validateStreetRequest = httpsPromise({
                     hostname: hostName,
                     path: encodeURI(`/recycle-public/app/v1/streets?q=${street}&zipcodes=${zipcodeId}`),
+                    method: "POST",
                     headers: {
                     'Content-Type': 'application/json',
                     'User-Agent': 'Homey',


### PR DESCRIPTION
overlooked that the streetRequest calls now needs to be a POST instead of a GET..


now again fully re-tested using repl online https://replit.com/@objtev/afvaltest#index.js
result for my home addres is 
{
  GFT: [ '2022-12-09', '2022-12-23' ],
  PMD: [ '2022-12-12', '2022-12-26' ],
  REST: [ '2022-12-13', '2022-12-27' ],
  PAPIER: [ '2022-12-13' ]
}