### PR TITLE
Added Waalre

### DIFF
--- a/assets/api-registry.json
+++ b/assets/api-registry.json
@@ -24,6 +24,7 @@
   { "name": "Afvalkalender Súdwest-Fryslân", "id": "swf", "country": "NL", "handler": "afvalkalenderSudwestFryslan" },
   { "name": "Afvalkalender Venlo", "id": "akvnl", "country": "NL", "handler": "afvalKalenderVenlo" },
   { "name": "Afvalkalender Venray", "id": "akvr", "country": "NL", "handler": "afvalkalenderVenray" },
+  { "name": "Afvalkalender Waalre", "id": "akwr", "country": "NL", "handler": "afvalkalenderWaalre" },
   { "name": "Afvalkalender Westland", "id": "akwl", "country": "NL", "handler": "afvalKalenderWestland" },
   { "name": "Afvalkalender Woerden", "id": "akwrd", "country": "NL", "handler": "afvalKalenderWoerden" },
   { "name": "Afvalkalender ZRD", "id": "afzrd", "country": "NL", "handler": "afvalkalenderZrd" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ A lot of cities are supported with this trashcan reminder. If your city is not s
 - [Afvalkalender RWM](https://rwm.nl)
 - [Afvalkalender Saver](https://saver.nl)
 - [Afvalkalender Venray](https://afvalkalender.venray.nl)
+- [Afvalkalender Waalre](https://afvalkalender.waalre.nl)
 - [Afvalkalender ZRD](https://afvalkalender.zrd.nl)
 - [Afvalwijzer Pre Zero](https://inzamelwijzer.prezero.nl/)
 - [Area Reiniging](https://www.area-afval.nl/voor-bewoners/afvalkalender/digitale-afvalkalender)

--- a/lib/trashapis.ts
+++ b/lib/trashapis.ts
@@ -301,6 +301,10 @@ export class TrashApis {
     return this.newGeneralAfvalkalendersNederlandRest(apiSettings, 'afvalkalender.alphenaandenrijn.nl');
   }
 
+  private async afvalkalenderWaalre(apiSettings: ApiSettings) {
+    return this.newGeneralAfvalkalendersNederlandRest(apiSettings, 'afvalkalender.waalre.nl');
+  }
+
   private async afvalKalenderVenlo(apiSettings: ApiSettings) {
     return this.generalImplementationWasteApi(apiSettings, '280affe9-1428-443b-895a-b90431b8ca31', 'wasteapi.ximmio.com');
   }

--- a/test/trashApiTests.ts
+++ b/test/trashApiTests.ts
@@ -117,6 +117,24 @@ describe('TrashApiApn', function () {
 });
 
 
+describe('TrashApiWaalre', function () {
+  it('API - Afvalkalender Waalre', async function () {
+    const apiSettings: ApiSettings = {
+      zipcode: '5581GK',
+      housenumber: '22',
+      country: 'NL',
+      apiId: 'akwr',
+      cleanApiId: '',
+      streetname: '',
+      cityname: '',
+    };
+
+    const result = await testAPI(apiSettings);
+    const isValid = validateApiResults(apiSettings, result);
+    assert.equal(isValid, true);
+  });
+});
+
 describe('TrashApiAkwl', function () {
   it('API - Afvalkalender Westland', async function () {
     const apiSettings: ApiSettings = {


### PR DESCRIPTION
## Summary
- Added support for Afvalkalender Waalre (`afvalkalender.waalre.nl`)
- Uses the existing `newGeneralAfvalkalendersNederlandRest` generic implementation
- Added API registry entry, handler method, docs entry, and test case

## Test plan
- [ ] Verify API responds correctly for Waalre addresses (e.g. `5581GK:22`)
- [ ] Run test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)